### PR TITLE
Fix open redirect

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ module.exports = function (options) {
     
     function redirect (redirectUrl) {
       var query = qs.stringify(req.query);
-      
+
+      if (redirectUrl.includes('//')) return next()
+
       redirectUrl += (query) ? '?' + query : '';
       res.writeHead(301, {Location: redirectUrl});
       res.end();


### PR DESCRIPTION
This PR fixes CVE-2021-3189 (https://github.com/advisories/GHSA-f4hq-453j-p95f). It ignores URLs that have 2 or more forward slashes in them. This should negate open redirects.

